### PR TITLE
Add support for basepath

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-scripts": "2.1.8",
-    "wouter": "1.2.0"
+    "wouter": "2.0.0"
   },
   "devDependencies": {
     "gh-pages": "^2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,46 @@
-import React from "react";
+import React, { useRef } from "react";
 import ReactDOM from "react-dom";
-import { Router, Route, Link } from "./lazy-wouter";
+
+import { Router } from "wouter";
+import useLocation from "wouter/use-location";
+import { LazySwitch, Route, Link } from "./lazy-wouter";
 
 import "./styles.css";
 
+const makeUseBasepathLocation = basepath => () => {
+  const [location, setLocation] = useLocation();
+
+  // could be done with regexp, but requires proper escaping
+  const normalized = location.startsWith(basepath)
+    ? location.slice(basepath.length)
+    : location;
+
+  return [normalized, to => setLocation(basepath + to)];
+};
+
+const useBasepathLocation = makeUseBasepathLocation("/wouter-async-routes");
+
 function App() {
   return (
-    <section>
-      <nav>
-        <Link to="/jquery">jquery</Link>
-        <Link to="/lodash">lodash</Link>
-        <Link to="/antd">antd</Link>
-      </nav>
+    <Router hook={useBasepathLocation}>
+      <section>
+        <nav>
+          <Link to="/jquery">jquery</Link>
+          <Link to="/lodash">lodash</Link>
+          <Link to="/antd">antd</Link>
+        </nav>
 
-      <main>
-        <center>
-          <Router fallback="loading...">
-            <Route path="/jquery" factory={() => import("./pages/jquery")} />
-            <Route path="/lodash" factory={() => import("./pages/lodash")} />
-            <Route path="/antd" factory={() => import("./pages/antd")} />
-          </Router>
-        </center>
-      </main>
-    </section>
+        <main>
+          <center>
+            <LazySwitch fallback="loading...">
+              <Route path="/jquery" factory={() => import("./pages/jquery")} />
+              <Route path="/lodash" factory={() => import("./pages/lodash")} />
+              <Route path="/antd" factory={() => import("./pages/antd")} />
+            </LazySwitch>
+          </center>
+        </main>
+      </section>
+    </Router>
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 import ReactDOM from "react-dom";
 
 import { Router } from "wouter";

--- a/src/lazy-wouter.js
+++ b/src/lazy-wouter.js
@@ -8,17 +8,14 @@ import React, {
   useContext
 } from "react";
 
-import { Router as WRouter, Link as WLink, useRoute } from "wouter";
+import { Link as WLink, useRoute } from "wouter";
 
 const PathsContext = createContext(new Map());
 const usePaths = () => useContext(PathsContext);
 
-const Router = ({ children, fallback }) => {
-  return (
-    <Suspense fallback={fallback}>
-      <WRouter>{children}</WRouter>
-    </Suspense>
-  );
+// TODO: not an actual switch!
+const LazySwitch = ({ children, fallback }) => {
+  return <Suspense fallback={fallback}>{children}</Suspense>;
 };
 
 const Route = ({ path, factory }) => {
@@ -31,7 +28,6 @@ const Route = ({ path, factory }) => {
 
     return () => paths.delete(path);
   }, [paths, path, factory]);
-  
 
   return matches && <Component />;
 };
@@ -39,7 +35,7 @@ const Route = ({ path, factory }) => {
 const Link = ({ to, ...props }) => {
   const paths = usePaths();
   const prefetch = useCallback(() => {
-    console.log('try prefetch route: ', to)
+    console.log("try prefetch route: ", to);
 
     if (paths.has(to)) {
       let fetcher = paths.get(to);
@@ -52,4 +48,4 @@ const Link = ({ to, ...props }) => {
   return <WLink to={to} {...props} onMouseEnter={prefetch} />;
 };
 
-export { Link, Route, Router };
+export { Link, Route, LazySwitch };


### PR DESCRIPTION
I had to upgrade wouter to v2, because that version has support for custom useLocation hooks. 

I also moved the Router to the top-level and had to rename `Router` to `LazySwitch` which is a temp solution. I have a better idea for this, I can express that in another PR.

See https://github.com/molefrog/wouter/issues/43